### PR TITLE
Fix Dynamic Cors: Use 'Origin' header instead of 'Referer'

### DIFF
--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -137,8 +137,8 @@ export class SdkgenHttpServer extends SdkgenServer {
             res.end();
         });
 
-        if (this.dynamicCorsOrigin && req.headers.referer) {
-            res.setHeader("Access-Control-Allow-Origin", req.headers.referer);
+        if (this.dynamicCorsOrigin && req.headers.origin) {
+            res.setHeader("Access-Control-Allow-Origin", req.headers.origin);
         }
 
         for (const [header, value] of this.headers) {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -139,6 +139,7 @@ export class SdkgenHttpServer extends SdkgenServer {
 
         if (this.dynamicCorsOrigin && req.headers.origin) {
             res.setHeader("Access-Control-Allow-Origin", req.headers.origin);
+            res.setHeader("Vary", "Origin");
         }
 
         for (const [header, value] of this.headers) {


### PR DESCRIPTION
[According to MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Access-Control-Allow-Origin), the `Origin` header should be used instead of `Referer` at `Access-Control-Allow-Origin`.

Additionally, we should include `Origin` in the `Vary` header to avoid caching of the wrong possible origin when different domains are consuming the API.